### PR TITLE
append global tags

### DIFF
--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -393,13 +393,19 @@ defmodule Statix do
   @doc false
   def transmit(conn, :event, title, text, options)
       when is_binary(title) and is_binary(text) and is_list(options) do
-    Conn.transmit(conn, :event, title, text, options)
+    Conn.transmit(conn, :event, title, text, put_global_tags(conn.sock, options))
   end
 
   @doc false
   def transmit(conn, :service_check, name, status, options)
       when is_binary(name) and is_atom(status) and is_list(options) do
-    Conn.transmit(conn, :service_check, name, to_string(status), options)
+    Conn.transmit(
+      conn,
+      :service_check,
+      name,
+      to_string(status),
+      put_global_tags(conn.sock, options)
+    )
   end
 
   @doc false

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -345,6 +345,9 @@ defmodule StatixTest do
 
     TestStatix.increment("sample", 3, tags: ["foo"])
     assert_receive {:server, "sample:3|c|#foo,tag:test"}
+
+    TestStatix.event("sample title", "sample text", tags: ["foo", "bar"])
+    assert_receive {:server, "_e{12,11}:sample title|sample text|#foo,bar,tag:test"}
   after
     Application.delete_env(:statix, :tags)
   end
@@ -357,6 +360,9 @@ defmodule StatixTest do
 
     TestStatix.increment("sample", 3, tags: ["foo"])
     assert_receive {:server, "sample:3|c|#foo,tag:test"}
+
+    TestStatix.event("sample title", "sample text", tags: ["foo", "bar"])
+    assert_receive {:server, "_e{12,11}:sample title|sample text|#foo,bar,tag:test"}
   after
     Application.delete_env(:statix, TestStatix)
   end


### PR DESCRIPTION
I've just noticed globally set tags from configuration are not appended to events and service checks so ... perhaps this was forgotten? Or intentional? 

Cheers
